### PR TITLE
Update Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,22 +22,9 @@ chmod 0600 dalc/celestia-app/celestia-light-keys
 ```
 This is done for you if you use the provided setup scripts in `scripts/`
 
-There are 4 different options for clusters to run.
-
-
-## Minimal Celestia Cluster
-> Not currently functional
-![](min-celestia.png "Minimum Viable Celestia Cluster")
-*Minimal Celestia Cluster*
-```
-scripts/minimal-celestia.sh
-```
-
-This is the most minimal cluster possible.
-
 ## Minimal Ethermint Cluster
 
-![](min-ethermint.png "Minimum Viable Ethermint Cluster")
+<!-- ![](min-ethermint.png "Minimum Viable Ethermint Cluster") -->
 *Minimal Ethermint Cluster*
 
 To setup the docker compose cluster run
@@ -53,7 +40,6 @@ Each container in the cluster has its own static IP Address. Clusters with only 
 | Core Node | 192.167.10.0 |
 | Bridge Nodes | 192.167.1.0 |
 | Light Nodes | 192.167.2.0 |
-| DALC  | 192.167.3.0 |
 | Ethermint | 192.167.4.0 |
 
 ### Interacting with the cluster

--- a/docker/minimal/bridge-docker-compose.yml
+++ b/docker/minimal/bridge-docker-compose.yml
@@ -1,8 +1,8 @@
 version: '3'
 
 services:
-  dalc0:
-    container_name: dalc0
+  bridge0:
+    container_name: bridge0
     image: "ghcr.io/celestiaorg/celestia-node:sha-f4e582e"
     environment:
       - NODE_TYPE=bridge
@@ -21,7 +21,7 @@ services:
 
     networks:
       localnet:
-        ipv4_address: 192.167.3.0
+        ipv4_address: 192.167.1.0
 
 networks:
   localnet:

--- a/ethermint/config/config.toml
+++ b/ethermint/config/config.toml
@@ -429,10 +429,10 @@ namespace = "tendermint"
 
 [optimint]
 aggregator = "true"
-block_time = "30s"
+block_time = "5s"
 namespace_id = "0001020304050607"
 da_layer = "celestia"
-da_config = '{"base_url":"http://192.167.3.0:26658","timeout":60000000000,"gas_limit":6000000,"namespace_id":[0,1,2,3,4,5,6,7]}'
+da_config = '{"base_url":"http://192.167.1.0:26658","timeout":60000000000,"gas_limit":6000000,"namespace_id":[0,1,2,3,4,5,6,7]}'
 
 [json-rpc]
 enable = "true"


### PR DESCRIPTION
- Shortens block time in `[optimint]` section of config.toml
- Removes diagrams since they're incorrect
- Removes references to `DALC` as that's not a thing anymore